### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,6 @@
     "repo": "googleapis/python-analytics-admin",
     "distribution_name": "google-analytics-admin",
     "api_id": "analyticsadmin.googleapis.com",
-    "default_version": "",
+    "default_version": "v1alpha",
     "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,6 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/python-analytics-admin",
     "distribution_name": "google-analytics-admin",
-    "api_id": "analyticsadmin.googleapis.com"
-  }
-  
+    "api_id": "analyticsadmin.googleapis.com",
+    "default_version": "",
+    "codeowner_team": ""
+}


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs. 

https://github.com/googleapis/synthtool/pull/1201
https://github.com/googleapis/synthtool/pull/1114