### PR TITLE
chore: configure release-please to use manifest

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,3 @@
 releaseType: python
 handleGHRelease: true
+manifest: true


### PR DESCRIPTION
This PR fixes an issue where `gapic_version.py` is not being updated by release-please. In PR https://github.com/googleapis/python-analytics-admin/pull/293, the version in `.release-please-manifest.json` is updated but the version in `google/analytics/admin/gapic_version.py` should also be updated.