### PR TITLE
chore: fix path to snippet metadata in release please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,12 +7,12 @@
         "google/analytics/admin/gapic_version.py",
         {
           "type": "json",
-          "path": "samples/generated_samples/snippet_metadata_admin_v1alpha.json",
+          "path": "samples/generated_samples/snippet_metadata_google.analytics.data.v1alpha.json",
           "jsonpath": "$.clientLibrary.version"
         },
         {
           "type": "json",
-          "path": "samples/generated_samples/snippet_metadata_admin_v1beta.json",
+          "path": "samples/generated_samples/snippet_metadata_google.analytics.data.v1beta.json",
           "jsonpath": "$.clientLibrary.version"
         }
       ]


### PR DESCRIPTION
The path to snippet metadata in `release-please-config.json` is wrong [here](https://github.com/googleapis/python-analytics-admin/blob/main/release-please-config.json#L10). 

Instead of `samples/generated_samples/snippet_metadata_admin_v1alpha.json` we should have `samples/generated_samples/snippet_metadata_google.analytics.admin.v1alpha.json`.

https://github.com/googleapis/python-analytics-admin/blob/main/samples/generated_samples/snippet_metadata_google.analytics.admin.v1alpha.json
